### PR TITLE
Setting the default timezone used by all date/time functions in the s…

### DIFF
--- a/make-zip.php
+++ b/make-zip.php
@@ -194,6 +194,7 @@ function edit_pot( $pot_URI ) {
 
 // Update the Underscores copyright year, if necessary.
 function update_s_copyright( $stylesheet ) {
+  date_default_timezone_set('UTC');
   $pattern = '/Underscores\shttp:\/\/underscores\.me\/?,?\s?\(C\)\s\d+-\d+/mi';
   $replacement = 'Underscores http://underscores.me/ (C) 2012-' . date( 'Y' );
   $stylesheet = preg_replace( $pattern, $replacement, $stylesheet );


### PR DESCRIPTION
…cript, to prevent PHP Warnings if timezone configuration is not present in php.ini.
