### PR TITLE
Swapping single quotes with smart quotes character entities for apostrophes

### DIFF
--- a/jetpack-dependency-script/plugin-enhancements.php
+++ b/jetpack-dependency-script/plugin-enhancements.php
@@ -89,7 +89,7 @@ class Theme_Plugin_Enhancements {
 					'slug'    => 'jetpack',
 	    		'name'    => 'Jetpack by WordPress.com',
 	    		'message' => sprintf(
-					__( 'The %1$s is required to use some of this theme\'s features, including: ', 'textdomain' ),
+					__( 'The %1$s is required to use some of this theme&rsquo;s features, including: ', 'textdomain' ),
 				'<strong>' . __( 'Jetpack plugin', 'textdomain' ) . '</strong>' ),
 					'modules' => $dependency_list . '.',
 				),
@@ -287,7 +287,7 @@ class Theme_Plugin_Enhancements {
 			endforeach;
 			$notice .= '<p>';
 			$notice .= sprintf(
-				__( 'To use %1$s, please activate the Jetpack plugin\'s %2$s.', 'textdomain' ),
+				__( 'To use %1$s, please activate the Jetpack plugin&rsquo;s %2$s.', 'textdomain' ),
 				esc_html( $featurelist ),
 				'<strong>' . esc_html( $this->get_module_name( $module ) ) . '</strong>'
 			);

--- a/jetpack-dependency-script/plugin-enhancements.pot
+++ b/jetpack-dependency-script/plugin-enhancements.pot
@@ -1,5 +1,5 @@
 #: inc/plugin-enhancements.php:92
-msgid "The %1$s is required to use some of this theme's features, including: "
+msgid "The %1$s is required to use some of this theme&rsquo;s features, including: "
 msgstr ""
 
 #: inc/plugin-enhancements.php:93
@@ -31,5 +31,5 @@ msgid "Install"
 msgstr ""
 
 #: inc/plugin-enhancements.php:290
-msgid "To use %1$s, please activate the Jetpack plugin's %2$s."
+msgid "To use %1$s, please activate the Jetpack plugin&rsquo;s %2$s."
 msgstr ""


### PR DESCRIPTION
Slightly better fix to keep the smart quotes in the Jetpack dependancy messages without the Theme Check plugin expressing its unhappiness.
