### PR TITLE
Make Jetpack dependancy script 'remember' dismissed notices

### DIFF
--- a/jetpack-dependency-script/plugin-enhancements.js
+++ b/jetpack-dependency-script/plugin-enhancements.js
@@ -1,0 +1,19 @@
+jQuery(document).ready(function($) {
+
+	/**
+	 *	Process request to dismiss our admin notice
+	 */
+	$('#jetpack-notice .notice-dismiss').click(function() {
+
+		//* Data to make available via the $_POST variable
+		data = {
+			action: 'textdomain_jetpack_admin_notice',
+			textdomain_jetpack_admin_nonce: textdomain_jetpack_admin.textdomain_jetpack_admin_nonce
+		};
+
+		//* Process the AJAX POST request
+		$.post( ajaxurl, data );
+
+		return false;
+	});
+});

--- a/org-submitter/make-zip.php
+++ b/org-submitter/make-zip.php
@@ -281,6 +281,13 @@ if ( true === $jetpack_dependency_script ) :
 	// Include it from within functions.php.
 	file_put_contents( $functions_URI, $include_jetpack_dependency, FILE_APPEND );
 
+	// Add plugin enhancements.js
+	$plugin_enhancements_js_URI = $theme_dir . 'inc/plugin-enhancements.js';
+	download_file( 'https://raw.githubusercontent.com/Automattic/theme-tools/master/jetpack-dependency-script/plugin-enhancements.js', $plugin_enhancements_js_URI );
+	$plugin_enhancements_js_content = read_file( $plugin_enhancements_js_URI );
+	$plugin_enhancements_js_content = replace_text_domain( $theme, $plugin_enhancements_js_content );
+	write_file( $plugin_enhancements_js_URI, $plugin_enhancements_js_content );
+
 	// Add extra strings to our .po file
 	$pot_URI = $theme_dir . '/languages/' . $theme . '.pot';
 	$extra_pot_URI = $theme_dir . '/languages/plugin-enhancements.php';


### PR DESCRIPTION
So this is my attempt to make the Jetpack dependency notices truly dismissible (see #14). It definitely needs some testing, corrections, and possibly an amount of rewriting before being merged, but hopefully gets the ball rolling!

I based it off of this tutorial here: https://www.engagewp.com/making-sense-working-with-ajax-wordpress/

Basically what happens is when a user dismisses the notice, the information is stored via Ajax in their user meta data. 

I'm not totally sure this is the best way to handle this for a few reasons:
- Once a user dismisses that notice for a specific theme, it will never appear for them for that theme again, even after clearing the cache. The state is remembered in the user's meta data.
- It's on a user by user basis. It's admin specific, so it wouldn't show up for every user on a site, but it will show up once for every admin user for each theme, even if another has dismissed it already.
- I'm not sure if storing this kind of information in the database is cool for a theme to do.

I'd love to get some feedback on the code, as well as the points above.

For testing locally, I went into make-zip.php and found the file paths starting with:

`download_file( 'https://raw.githubusercontent.com/Automattic/theme-tools/master/jetpack-dependency-script/...`

and changed them to point to where the files were hosted locally, like:

`download_file( ‘http://localhost:8888/theme-tools/jetpack-dependency-script/...`

The exact URL will depend on your local setup, but you get the idea.

It’s also worth noting that my localhost didn’t like dealing with the plugin-enhancements.php file when running make-zip.php locally -- I think this is because it wasn't being served up 'raw' like it is from Github. I worked around this by temporarily changing the extension of the file to .html, both for the file itself and the `download_file` reference in make-zip.php. The make-zip.php creates a second copy of this file in the theme and copies the contents over, so the incorrect extension in the /theme-tools/ file didn't seem to cause any issues.

Lastly, based on the above, you can re-test dismissing the message in a specific theme by switching to a different admin user.
