### PR TITLE
Remove the jetpack-fonts.php file

### DIFF
--- a/org-submitter/make-zip.php
+++ b/org-submitter/make-zip.php
@@ -190,6 +190,7 @@ $updater_URI = $theme_dir . 'inc/updater.php';
 $headstart_dir = $theme_dir . 'inc/headstart/';
 $pot_URI = $theme_dir . 'languages/'.$theme.'.pot';
 $footer_URI = $theme_dir . 'footer.php';
+$fonts_URI = $theme_dir . 'inc/jetpack-fonts.php';
 
 // Make sure the theme URI is set correctly.
 function set_theme_URI( $theme, $stylesheet ) {
@@ -305,6 +306,8 @@ delete_file( $updater_URI );
 if ( is_dir( $headstart_dir ) ) {
     delete_directory( $headstart_dir );
 }
+// Remove the WPCOM-only custom font annotations file.
+delete_file( $fonts_URI );
 
 // Edit .pot file.
 $new_pot = edit_pot( $pot_URI );

--- a/org-submitter/make-zip.php
+++ b/org-submitter/make-zip.php
@@ -307,7 +307,9 @@ if ( is_dir( $headstart_dir ) ) {
     delete_directory( $headstart_dir );
 }
 // Remove the WPCOM-only custom font annotations file.
-delete_file( $fonts_URI );
+if ( file_exists( $fonts_URI ) ) {
+	delete_file( $fonts_URI );
+}
 
 // Edit .pot file.
 $new_pot = edit_pot( $pot_URI );


### PR DESCRIPTION
Since font annotations file is now included inside theme folder, we should probably remove it while generating .zip for WordPress.org.